### PR TITLE
[#4] Add token tree dialog plus extend token support

### DIFF
--- a/metatag.info.yml
+++ b/metatag.info.yml
@@ -3,3 +3,5 @@ type: module
 description: Adds support and an API to implement meta tags.
 core: 8.x
 package: SEO
+dependencies:
+  - token

--- a/metatag.module
+++ b/metatag.module
@@ -9,32 +9,40 @@
  * Load all meta tags for this page.
  */
 function metatag_page_attachments(array &$attachments) {
-  $metatag = entity_load('metatag_context', 'global');
+  $metatags = array();
+  $metatag_context = entity_load('metatag_context', 'global');
 
-  if (!empty($metatag)) {
-    $metatags = array(
-      'description' => array(
+  if (!empty($metatag_context)) {
+    if (!empty($metatag_context->get('description'))) {
+      $metatags['description'] = array(
         '#tag' => 'meta',
         '#attributes' => array(
           'name' => 'description',
-          'content' => $metatag->get('description'),
+          'content' => \Drupal::token()->replace($metatag_context->get('description')),
         ),
-      ),
-      'abstract' => array(
+      );
+    }
+    if (!empty($metatag_context->get('abstract'))) {
+      $metatags['abstract'] = array(
         '#tag' => 'meta',
         '#attributes' => array(
           'name' => 'abstract',
-          'content' => $metatag->get('abstract'),
+          'content' => \Drupal::token()->replace($metatag_context->get('abstract')),
         ),
-      ),
-      'keywords' => array(
+      );
+    }
+    if (!empty($metatag_context->get('keywords'))) {
+      $metatags['keywords'] = array(
         '#tag' => 'meta',
         '#attributes' => array(
           'name' => 'keywords',
-          'content' => $metatag->get('keywords'),
+          'content' => \Drupal::token()->replace($metatag_context->get('keywords')),
         ),
-      ),
-    );
+      );
+    }
+  }
+
+  if (!empty($metatags)) {
     foreach ($metatags as $key => $value) {
       $attachments['#attached']['html_head'][] = [$value, $key];
     }
@@ -46,10 +54,12 @@ function metatag_page_attachments(array &$attachments) {
  */
 function metatag_preprocess_html(array &$variables) {
   // Alter the page title.
-  $metatag = entity_load('metatag_context', 'global');
-  if (!empty($metatag)) {
-    if (!empty($metatag->get('title'))) {
-      $variables['head_title'] = array('metatag' => $metatag->get('title'));
+  $metatag_global = entity_load('metatag_context', 'global');
+  if (!empty($metatag_global)) {
+    $title = $metatag_global->get('title');
+    if (!empty($title)) {
+      $processed_title = \Drupal::token()->replace($title);
+      $variables['head_title'] = array('metatag' => $processed_title);
     }
   }
 }

--- a/src/Form/MetatagContextForm.php
+++ b/src/Form/MetatagContextForm.php
@@ -26,6 +26,21 @@ class MetatagContextForm extends EntityForm {
 
     $metatag_context = $this->entity;
 
+    // Add the token list to the top of the fieldset.
+    $form['tokens'] = array(
+      '#theme' => 'token_tree',
+      '#token_types' => array(),
+      '#global_types' => TRUE,
+      '#click_insert' => TRUE,
+      '#show_restricted' => FALSE,
+      '#recursion_limit' => 3,
+      '#dialog' => TRUE,
+    );
+
+    $form['intro_text'] = array(
+      '#markup' => '<p>' . t('Configure the meta tags below. Use tokens (see the "Browse available tokens" popup) to avoid redundant meta data and search engine penalization. For example, a \'keyword\' value of "example" will be shown on all content using this configuration, whereas using the [node:field_keywords] automatically inserts the "keywords" values from the current entity (node, term, etc).') . '</p>',
+    );
+
     $form['title'] = array(
       '#type' => 'textfield',
       '#title' => $this->t('Page title'),


### PR DESCRIPTION
- Adds the token tree link and dialog at the top of a metatag defaults
  form.
- Adds token support for the rest of the metatags.
- Adds token module as a dependency.
