### PR TITLE
1 move rendering to plugins

### DIFF
--- a/metatag.module
+++ b/metatag.module
@@ -26,13 +26,8 @@ function metatag_page_attachments(array &$attachments) {
       if ($metatag_defaults->hasTag($tag_id)) {
         $tag->setValue($metatag_defaults->getTag($tag_id));
         $metatags[$tag_id] = $tag->render();
+        $attachments['#attached']['html_head'][] = [$tag->render(), $tag_id];
       }
-    }
-  }
-
-  if (!empty($metatags)) {
-    foreach ($metatags as $key => $value) {
-      $attachments['#attached']['html_head'][] = [$value, $key];
     }
   }
 }

--- a/metatag.module
+++ b/metatag.module
@@ -13,32 +13,20 @@ function metatag_page_attachments(array &$attachments) {
   $metatag_defaults = entity_load('metatag_defaults', 'global');
 
   if (!empty($metatag_defaults)) {
-    if ($metatag_defaults->hasTag('description')) {
-      $metatags['description'] = array(
-        '#tag' => 'meta',
-        '#attributes' => array(
-          'name' => 'description',
-          'content' => \Drupal::token()->replace($metatag_defaults->getTag('description')),
-        ),
-      );
-    }
-    if ($metatag_defaults->hasTag('abstract')) {
-      $metatags['abstract'] = array(
-        '#tag' => 'meta',
-        '#attributes' => array(
-          'name' => 'abstract',
-          'content' => \Drupal::token()->replace($metatag_defaults->getTag('abstract')),
-        ),
-      );
-    }
-    if ($metatag_defaults->hasTag('keywords')) {
-      $metatags['keywords'] = array(
-        '#tag' => 'meta',
-        '#attributes' => array(
-          'name' => 'keywords',
-          'content' => \Drupal::token()->replace($metatag_defaults->getTag('keywords')),
-        ),
-      );
+    // Load all tag plugins.
+    $tag_manager = \Drupal::service('plugin.manager.metatag.tag');
+    $tags = $tag_manager->getDefinitions();
+    // Remove the title tag as it is processed at metatag_preprocess_html().
+    unset($tags['title']);
+
+    // Loop plugins and render them.
+    foreach ($tags as $tag_id => $tag_definition) {
+      $tag = $tag_manager->createInstance($tag_id);
+      // If the config_entity has a value for this tag, set it.
+      if ($metatag_defaults->hasTag($tag_id)) {
+        $tag->setValue($metatag_defaults->getTag($tag_id));
+        $metatags[$tag_id] = $tag->render();
+      }
     }
   }
 

--- a/src/Plugin/metatag/Tag/MetaNameBase.php
+++ b/src/Plugin/metatag/Tag/MetaNameBase.php
@@ -81,14 +81,6 @@ abstract class MetaNameBase extends PluginBase {
   }
 
   /**
-   * @return bool
-   *   Whether this meta tag has been enabled.
-   */
-  public function isActive() {
-    return TRUE;
-  }
-
-  /**
    * Generate a form element for this meta tag.
    */
   public function form() {
@@ -113,17 +105,24 @@ abstract class MetaNameBase extends PluginBase {
     $this->value = $value;
   }
 
-  public function output() {
+  /**
+   * Renders this tag.
+   *
+   * @return
+   *   The HTML that represents this tag.
+   */
+  public function render() {
     if (empty($this->value)) {
       // If there is no value, we don't want a tag output.
       $element = '';
     }
     else {
+      $processed_value = \Drupal::token()->replace($this->value);
       $element = array(
         '#tag' => 'meta',
         '#attributes' => array(
           'name' => $this->name,
-          'content' => $this->value(),
+          'content' => $processed_value,
         )
       );
     }


### PR DESCRIPTION
This PR moves tag rendering to its plugins, which sets the foundation for all types of tags within the `<head>` section such as `base`, `link` and `meta`.
