### PR TITLE
3 entity defaults

### DIFF
--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -1,2 +1,5 @@
 id: 'node'
 label: 'Node'
+tags:
+  title: '[node:title] | [site:name]'
+  description: '[node:summary]'

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -1,0 +1,2 @@
+id: 'node'
+label: 'Node'

--- a/config/install/metatag.metatag_defaults.taxonomy.yml
+++ b/config/install/metatag.metatag_defaults.taxonomy.yml
@@ -1,2 +1,5 @@
 id: 'taxonomy'
 label: 'Taxonomy'
+tags:
+  title: '[term:name] | [site:name]'
+  description: '[term:description]'

--- a/config/install/metatag.metatag_defaults.taxonomy.yml
+++ b/config/install/metatag.metatag_defaults.taxonomy.yml
@@ -1,0 +1,2 @@
+id: 'taxonomy'
+label: 'Taxonomy'

--- a/config/install/metatag.metatag_defaults.user.yml
+++ b/config/install/metatag.metatag_defaults.user.yml
@@ -1,0 +1,2 @@
+id: 'user'
+label: 'User'

--- a/config/install/metatag.metatag_defaults.user.yml
+++ b/config/install/metatag.metatag_defaults.user.yml
@@ -1,2 +1,5 @@
 id: 'user'
 label: 'User'
+tags:
+  title: '[user:name] | [site:name]'
+  description: '[site:name]'

--- a/metatag.module
+++ b/metatag.module
@@ -9,10 +9,9 @@
  * Load all meta tags for this page.
  */
 function metatag_page_attachments(array &$attachments) {
-  $metatags = array();
-  $metatag_defaults = entity_load('metatag_defaults', 'global');
+  $metatags = metatag_get_tags_from_route();
 
-  if (!empty($metatag_defaults)) {
+  if (!empty($metatags)) {
     // Load all tag plugins.
     $tag_manager = \Drupal::service('plugin.manager.metatag.tag');
     $tags = $tag_manager->getDefinitions();
@@ -23,8 +22,8 @@ function metatag_page_attachments(array &$attachments) {
     foreach ($tags as $tag_id => $tag_definition) {
       $tag = $tag_manager->createInstance($tag_id);
       // If the config_entity has a value for this tag, set it.
-      if ($metatag_defaults->hasTag($tag_id)) {
-        $tag->setValue($metatag_defaults->getTag($tag_id));
+      if (isset($metatags[$tag_id])) {
+        $tag->setValue($metatags[$tag_id]);
         $metatags[$tag_id] = $tag->render();
         $attachments['#attached']['html_head'][] = [$tag->render(), $tag_id];
       }
@@ -37,11 +36,59 @@ function metatag_page_attachments(array &$attachments) {
  */
 function metatag_preprocess_html(array &$variables) {
   // Alter the page title.
-  $metatag_global = entity_load('metatag_defaults', 'global');
-  if (!empty($metatag_global)) {
-    if ($metatag_global->hasTag('title')) {
-      $processed_title = \Drupal::token()->replace($metatag_global->getTag('title'));
+  $metatags = metatag_get_tags_from_route();
+  if (!empty($metatags)) {
+    if (isset($metatags['title'])) {
+      $processed_title = \Drupal::token()->replace($metatags['title']);
       $variables['head_title'] = array('metatag' => $processed_title);
     }
   }
 }
+
+/**
+ * Load the meta tags by processing the route parameters.
+ *
+ * @return array()
+ *   All of the meta tags identified for the header.
+ */
+function metatag_get_tags_from_route() {
+  $metatags = entity_load('metatag_defaults', 'global');
+
+  // Load the current route.
+  $route_match = \Drupal::routeMatch();
+
+  // Look for a canonical entity view page, e.g. node/{nid}, user/{uid}, etc.
+  $entity_type = metatag_is_supported_route($route_match->getRouteName());
+
+  // Check if there are default metatags for this entity type.
+  if (!empty($entity_type)) {
+    $entity_metatags = entity_load('metatag_defaults', $entity_type);
+    if ($entity_metatags != NULL) {
+      $metatags->set('tags', array_merge($metatags->get('tags'), $entity_metatags->get('tags')));
+    }
+  }
+
+  return $metatags->get('tags');
+}
+
+/**
+ * Identify whether a route is supported by the module.
+ *
+ * @param string $route_name
+ *
+ * @return bool
+ */
+function metatag_is_supported_route($route_name) {
+  $supported = FALSE;
+
+  // Look for a canonical entity view page, e.g. node/{nid}, user/{uid}, etc.
+  $matches = array();
+
+  preg_match('/entity\.(.*)\.canonical/', $route_name, $matches);
+  if (!empty($matches[1])) {
+    $supported = $matches[1];
+  }
+
+  return $supported;
+}
+

--- a/src/Tests/MetatagAdminTest.php
+++ b/src/Tests/MetatagAdminTest.php
@@ -18,7 +18,7 @@ class MetatagAdminTest extends WebTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = array('metatag', 'node', 'datetime', 'comment', 'views', 'block', 'devel');
+  public static $modules = array('metatag', 'node');
 
   /**
    * {@inheritdoc}
@@ -106,7 +106,7 @@ class MetatagAdminTest extends WebTestBase {
    */
   function testEntityOverrides() {
     // Initiate session with a user who can manage metatags.
-    $permissions = array('administer site configuration', 'administer metatags', 'access content', 'create article content', 'administer nodes', 'create article content', 'create page content', 'post comments');
+    $permissions = array('administer site configuration', 'administer metatags', 'access content', 'create article content', 'administer nodes', 'create article content', 'create page content');
     $account = $this->drupalCreateUser($permissions);
     $this->drupalLogin($account);
 

--- a/src/Tests/MetatagAdminTest.php
+++ b/src/Tests/MetatagAdminTest.php
@@ -70,7 +70,6 @@ class MetatagAdminTest extends WebTestBase {
     $this->assertText('Saved the Global Metatag defaults.');
 
     // Check that the new values are found in the response.
-    $this->drupalGet('<front>');
     foreach ($values as $metatag => $value) {
       $this->assertRaw($value, t('Updated metatag @tag was found in the HEAD section of the page.', array('@tag' => $metatag)));
     }

--- a/src/Tests/MetatagAdminTest.php
+++ b/src/Tests/MetatagAdminTest.php
@@ -18,7 +18,24 @@ class MetatagAdminTest extends WebTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = array('metatag');
+  public static $modules = array('metatag', 'node', 'datetime', 'comment', 'views', 'block', 'devel');
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Create Basic page and Article node types.
+    if ($this->profile != 'standard') {
+      $this->drupalCreateContentType(array(
+        'type' => 'page',
+        'name' => 'Basic page',
+        'display_submitted' => FALSE,
+      ));
+      $this->drupalCreateContentType(array('type' => 'article', 'name' => 'Article'));
+    }
+  }
 
   /**
    * Tests the interface to manage metatag defaults.
@@ -80,6 +97,71 @@ class MetatagAdminTest extends WebTestBase {
     $this->assertText('Saved the Global Metatag defaults.');
     $robots_value = implode(', ', $robots_values);
     $this->assertRaw($robots_value, t('Robots metatag has the expected values.'));
+    $this->drupalLogout();
+  }
+
+
+  /**
+   * Tests entity overrides.
+   */
+  function testEntityOverrides() {
+    // Initiate session with a user who can manage metatags.
+    $permissions = array('administer site configuration', 'administer metatags', 'access content', 'create article content', 'administer nodes', 'create article content', 'create page content', 'post comments');
+    $account = $this->drupalCreateUser($permissions);
+    $this->drupalLogin($account);
+
+    // Create a a test node.
+    $node = $this->drupalCreateNode(array(
+      'title' => t('Hello, world!'),
+      'type' => 'article',
+    ));
+
+    // Update the Metatag Node defaults.
+    $values = array(
+      'title' => 'Test title for a node.',
+      'description' => 'Test description for a node.',
+    );
+    $this->drupalPostForm('admin/structure/metatag_defaults/node', $values, 'Save');
+    $this->assertText('Saved the Node Metatag defaults.');
+
+    // Check that the new values are found in the response.
+    $this->drupalGet('node/' . $node->id());
+    foreach ($values as $metatag => $value) {
+      $this->assertRaw($value, t('Node metatag @tag overrides Global defaults.', array('@tag' => $metatag)));
+    }
+
+    /**
+     * Check that when the node defaults don't define a metatag, the Global one is used.
+     */
+    // First unset node defaults.
+    $values = array(
+      'title' => '',
+      'description' => '',
+    );
+    $this->drupalPostForm('admin/structure/metatag_defaults/node', $values, 'Save');
+    $this->assertText('Saved the Node Metatag defaults.');
+    $this->drupalGet('admin/structure/metatag_defaults/node');
+
+    // Then, set global ones.
+    $values = array(
+      'title' => 'Global title',
+      'description' => 'Global description',
+    );
+    $this->drupalPostForm('admin/structure/metatag_defaults/global', $values, 'Save');
+    $this->assertText('Saved the Global Metatag defaults.');
+    $this->drupalGet('admin/structure/metatag_defaults/global');
+
+    // Next, test that global defaults are rendered since node ones are empty.
+    // We are creating a new node as doing a get on the previous one would
+    // return cached results.
+    $node = $this->drupalCreateNode(array(
+      'title' => t('Hello, world!'),
+      'type' => 'article',
+    ));
+    $this->drupalGet('node/' . $node->id());
+    foreach ($values as $metatag => $value) {
+      $this->assertRaw($value, t('Found global @tag tag as Node does not set it.', array('@tag' => $metatag)));
+    }
   }
 
 }


### PR DESCRIPTION
This pull request adds defaults for node, user and taxonomy entities. I have not implemented a dynamic way to discover supported entities as the Drupal 7 version does, but this could be implemented afterwards.

![ui](https://cloud.githubusercontent.com/assets/108130/11366495/e3b40612-92ad-11e5-9ba0-709fa950ecde.png)
