### PR TITLE
[#15] Process field default for Robots

### DIFF
--- a/src/MetatagManager.php
+++ b/src/MetatagManager.php
@@ -296,10 +296,16 @@ class MetatagManager implements MetatagManagerInterface {
         if ($entity) {
           $token_replacements = array($entity->getEntityTypeId() => $entity);
         }
-        $value = $this->tokenService->tokenReplace($value, $token_replacements);
 
-        // Tell the plugin what value to use for the metatag content.
+        // Set the value as sometimes the data needs massaging, such as when
+        // field defaults are used for the Robots field, which come as an array
+        // that needs to be filtered and converted to a string.
+        // @see @Robots::setValue().
         $tag->setValue($value);
+        $processed_value = $this->tokenService->tokenReplace($tag->value(), $token_replacements);
+
+        // Now store the value with processed tokens back into the plugin.
+        $tag->setValue($processed_value);
 
         // Have the tag generate the output based on the value we gave it.
         $output = $tag->output();

--- a/src/Plugin/metatag/Tag/Robots.php
+++ b/src/Plugin/metatag/Tag/Robots.php
@@ -23,18 +23,20 @@ use Drupal\metatag\Annotation\MetatagTag;
  * )
  */
 class Robots extends MetaNameBase {
+
   /**
    * Sets the value of this tag.
    *
    * @param string|array $value
    *   The value to set to this tag.
-   *   It can be an array if it comes from a form submission, in which case
+   *   It can be an array if it comes from a form submission or from field
+   *   defaults, in which case
    *   we transform it to a comma-separated string.
    */
   public function setValue($value) {
     if (is_array($value)) {
       $value = array_filter($value);
-      $value = implode(', ', $value);
+      $value = implode(', ', array_keys($value));
     }
     $this->value = $value;
   }


### PR DESCRIPTION
Field defaults come as an array instead of a string and therefore need
to be processed or Token module will raise errors.
