### PR TITLE
[#15] Don't allow global and entity defaults to be deleted

### DIFF
--- a/metatag.module
+++ b/metatag.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\metatag\Entity\MetatagDefaults;
 
 /**
  * Implements hook_help().
@@ -24,6 +25,24 @@ tags", about your website and web pages.') . '</p>';
   }
 
   return $output;
+}
+
+/**
+ * Alter entity operations.
+ *
+ * @param array $operations
+ *   Operations array as returned by
+ *   \Drupal\Core\Entity\EntityListBuilderInterface::getOperations().
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity on which the linked operations will be performed.
+ */
+function metatag_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity) {
+  // Remove the Delete operation in global and entity defaults.
+  if ($entity instanceof MetatagDefaults) {
+    if (strpos($entity->id(), '__') === FALSE) {
+      unset($operations['delete']);
+    }
+  }
 }
 
 /**

--- a/src/Tests/MetatagAdminTest.php
+++ b/src/Tests/MetatagAdminTest.php
@@ -55,6 +55,10 @@ class MetatagAdminTest extends WebTestBase {
     // Check that the Global defaults were created.
     $this->assertLinkByHref('/admin/structure/metatag_defaults/global', 0, t('Global defaults were created on installation.'));
 
+    // Check that Global and entity defaults can't be deleted.
+    $this->assertNoLinkByHref('/admin/structure/metatag_defaults/global/delete', 0, t('Global defaults can\'t be deleted'));
+    $this->assertNoLinkByHref('/admin/structure/metatag_defaults/node/delete', 0, t('Entity defaults can\'t be deleted'));
+
     // Check that the module defaults were injected into the Global config entity.
     $this->drupalGet('admin/structure/metatag_defaults/global');
     $this->assertFieldById('edit-title', $metatag_defaults->get('title'), t('Metatag defaults were injected into the Global configuration entity.'));


### PR DESCRIPTION
This is how the admin interface looks like with this change:

![image](https://cloud.githubusercontent.com/assets/108130/11441941/31730b5e-9511-11e5-9d68-06e5cffbafa2.png)
