### PR TITLE
Restore bundle defaults

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -44,17 +44,20 @@ Standard usage scenario
    automatically assign values. If the Token module is enabled there will be a
    "Browse available tokens" link that opens a popup to list & insert the
    available tokens.
-4. If you want to set bundle/conent type overrides, go to the "Manage fields"
-   page for that entity, e.g. for an "Article" content type it would be:
-   admin/structure/types/manage/article/fields.
+4. You can add bundle defaults by clicking on "Add metatag defaults" and filling
+   out the form.
+5. If you want to adjust metatags for a specific entity, then you need to add
+   the Metatag field. Follow these steps:
 
-  4.1 Select "Meta tags" from the "Add a new field" selector.
-  4.2 Fill in a label for the field, e.g. "Meta tags", and set an appropiate
-      machine name, e.g. "meta_tags".
-  4.3 Click the "Save and continue" button.
-  4.5 If the site supports multiple languages, and translations have been
-      enabled for this entity, select "Users may translate this field" to use
-      Drupal's translation system.
+   5.1 Go to the "Manage fields" of the bundle where you want the metatag field
+       to appear.
+   5.2 Select "Meta tags" from the "Add a new field" selector.
+   5.3 Fill in a label for the field, e.g. "Meta tags", and set an appropiate
+       machine name, e.g. "meta_tags".
+   5.4 Click the "Save and continue" button.
+   5.5 If the site supports multiple languages, and translations have been
+       enabled for this entity, select "Users may translate this field" to use
+       Drupal's translation system.
 
 DrupalConsole integration
 --------------------------------------------------------------------------------

--- a/metatag.install
+++ b/metatag.install
@@ -6,6 +6,13 @@
  */
 
 /**
+ * Implements hook_install().
+ */
+function metatag_install() {
+  drupal_set_message(t("To adjust global defaults, go to admin/structure/metatag_defaults. If you need to set metatags for a specific entity, edit it's bundle and add the Metatag field."));
+}
+
+/**
  * Remove tags in field storage that match default or are empty.
  */
 function metatag_update_8101() {

--- a/metatag.links.action.yml
+++ b/metatag.links.action.yml
@@ -1,0 +1,6 @@
+entity.metatag_defaults.add_form:
+  route_name: 'entity.metatag_defaults.add_form'
+  title: 'Add Metatag defaults'
+  appears_on:
+    - entity.metatag_defaults.collection
+

--- a/metatag.module
+++ b/metatag.module
@@ -32,13 +32,22 @@ tags", about your website and web pages.') . '</p>';
  */
 function metatag_form_field_storage_config_edit_form_alter(&$form, FormStateInterface $form_state) {
   if ($form_state->getFormObject()->getEntity()->getType() == 'metatag') {
-    // Disable the cardinality option on the field storage settings form for
-    // metatag fields.
-    $form['cardinality_container']['#prefix'] = t("Metatag fields must be singular.");
+    // Hide the cardinality field.
+    $form['cardinality_container']['#access'] = FALSE;
     $form['cardinality_container']['#disabled'] = TRUE;
-    $form['cardinality_container']['cardinality']['#disabled'] = TRUE;
-    $form['cardinality_container']['cardinality_number']['#disabled'] = TRUE;
-    unset($form['cardinality_container']['cardinality_number']['#states']);
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for 'field_config_edit_form'.
+ */
+function metatag_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state) {
+  if ($form_state->getFormObject()->getEntity()->getType() == 'metatag') {
+    // Hide the cardinality field.
+    $form['required']['#access'] = FALSE;
+    $form['required']['#disabled'] = TRUE;
+    $form['default_value']['#access'] = FALSE;
+    $form['default_value']['#disabled'] = TRUE;
   }
 }
 
@@ -226,6 +235,13 @@ function metatag_get_default_tags() {
     if ($entity_metatags != NULL) {
       // Merge with global defaults.
       $metatags->set('tags', array_merge($metatags->get('tags'), $entity_metatags->get('tags')));
+    }
+
+    // Finally, check if we should apply bundle overrides.
+    $bundle_metatags = entity_load('metatag_defaults', $entity->getEntityTypeId() . '__' . $entity->bundle());
+    if ($bundle_metatags != NULL) {
+      // Merge with existing defaults.
+      $metatags->set('tags', array_merge($metatags->get('tags'), $bundle_metatags->get('tags')));
     }
   }
   return $metatags->get('tags');

--- a/metatag.routing.yml
+++ b/metatag.routing.yml
@@ -9,11 +9,31 @@ entity.metatag_defaults.collection:
   options:
     _admin_route: TRUE
 
+entity.metatag_defaults.add_form:
+  path: '/admin/structure/metatag_defaults/add'
+  defaults:
+    _entity_form: 'metatag_defaults.add'
+    _title: 'Add Metatag defaults'
+  requirements:
+    _permission: 'administer meta tags'
+  options:
+    _admin_route: TRUE
+
 entity.metatag_defaults.edit_form:
   path: '/admin/structure/metatag_defaults/{metatag_defaults}'
   defaults:
     _entity_form: 'metatag_defaults.edit'
     _title: 'Edit Metatag defaults'
+  requirements:
+    _permission: 'administer meta tags'
+  options:
+    _admin_route: TRUE
+
+entity.metatag_defaults.delete_form:
+  path: '/admin/structure/metatag_defaults/{metatag_defaults}/delete'
+  defaults:
+    _entity_form: 'metatag_defaults.delete'
+    _title: 'Delete Metatag defaults'
   requirements:
     _permission: 'administer meta tags'
   options:

--- a/src/Entity/MetatagDefaults.php
+++ b/src/Entity/MetatagDefaults.php
@@ -22,7 +22,9 @@ use Drupal\metatag\MetatagDefaultsInterface;
  *   handlers = {
  *     "list_builder" = "Drupal\metatag\MetatagDefaultsListBuilder",
  *     "form" = {
+ *       "add" = "Drupal\metatag\Form\MetatagDefaultsForm",
  *       "edit" = "Drupal\metatag\Form\MetatagDefaultsForm",
+ *       "delete" = "Drupal\metatag\Form\MetatagDefaultsDeleteForm",
  *       "revert" = "Drupal\metatag\Form\MetatagDefaultsRevertForm"
  *     }
  *   },
@@ -35,6 +37,7 @@ use Drupal\metatag\MetatagDefaultsInterface;
  *   links = {
  *     "canonical" = "/admin/structure/metatag_defaults/{metatag_defaults}",
  *     "edit-form" = "/admin/structure/metatag_defaults/{metatag_defaults}/edit",
+ *     "delete-form" = "/admin/structure/metatag_defaults/{metatag_defaults}/delete",
  *     "revert-form" = "/admin/structure/metatag_defaults/{metatag_defaults}/revert",
  *     "collection" = "/admin/structure/visibility_group"
  *   }

--- a/src/Form/MetatagDefaultsDeleteForm.php
+++ b/src/Form/MetatagDefaultsDeleteForm.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\metatag\Form\MetatagDefaultsDeleteForm.
+ */
+
+namespace Drupal\metatag\Form;
+
+use Drupal\Core\Entity\EntityConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+/**
+ * Builds the form to delete Metatag defaults entities.
+ */
+class MetatagDefaultsDeleteForm extends EntityConfirmFormBase {
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to delete %name?', array('%name' => $this->entity->label()));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('entity.metatag_defaults.collection');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->entity->delete();
+
+    drupal_set_message(
+      $this->t('Deleted @label defaults.',
+        [
+          '@label' => $this->entity->label()
+        ]
+        )
+    );
+
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/src/Form/MetatagDefaultsForm.php
+++ b/src/Form/MetatagDefaultsForm.php
@@ -29,6 +29,18 @@ class MetatagDefaultsForm extends EntityForm {
 
     $form += \Drupal::service('metatag.token')->tokenBrowser();
 
+    // If this is a new Metatag defaults, then list available bundles.
+    if ($metatag_defaults->isNew()) {
+      $options = $this->getAvailableBundles();
+      $form['id'] = array(
+        '#type' => 'select',
+        '#title' => t('Type'),
+        '#description' => t('Select the type of default meta tags you would like to add.'),
+        '#options' => $options,
+        '#required' => TRUE,
+      );
+    }
+
     // Load all tag plugins and render their form representation.
     $tag_manager = \Drupal::service('plugin.manager.metatag.tag');
     $tags = $tag_manager->getDefinitions();
@@ -50,6 +62,21 @@ class MetatagDefaultsForm extends EntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $metatag_defaults = $this->entity;
 
+    // Set the label on new defaults.
+    if ($metatag_defaults->isNew()) {
+      $metatag_defaults_id = $form_state->getValue('id');
+      list($entity_type, $entity_bundle) = explode('__', $metatag_defaults_id);
+      // Get the entity label.
+      $entity_manager = \Drupal::service('entity.manager');
+      $entity_info = $entity_manager->getDefinitions();
+      $entity_label = (string) $entity_info[$entity_type]->get('label');
+      // Get the bundle label.
+      $bundle_info = $entity_manager->getBundleInfo($entity_type);
+      $bundle_label = $bundle_info[$entity_bundle]['label'];
+      // Set the label to the config entity.
+      $this->entity->set('label', $entity_label . ': ' . $bundle_label);
+    }
+
     // Set tags within the Metatag entity.
     $tag_manager = \Drupal::service('plugin.manager.metatag.tag');
     $tags = $tag_manager->getDefinitions();
@@ -67,11 +94,46 @@ class MetatagDefaultsForm extends EntityForm {
     }
     $metatag_defaults->set('tags', $tag_values);
     $status = $metatag_defaults->save();
-    drupal_set_message($this->t('Saved the %label Metatag defaults.', [
-      '%label' => $metatag_defaults->label(),
-    ]));
+
+    switch ($status) {
+      case SAVED_NEW:
+        drupal_set_message($this->t('Created the %label Metatag defaults.', [
+          '%label' => $metatag_defaults->label(),
+        ]));
+        break;
+      default:
+        drupal_set_message($this->t('Saved the %label Metatag defaults.', [
+          '%label' => $metatag_defaults->label(),
+        ]));
+    }
 
     $form_state->setRedirectUrl($metatag_defaults->urlInfo('collection'));
+  }
+
+  /**
+   * Returns an array of available bundles to override.
+   *
+   * @return array
+   *   A list of available bundles as $id => $label.
+   */
+  protected function getAvailableBundles() {
+    $options = array();
+    // @TODO discover supported entities.
+    $entity_types = array(
+      'node' => 'Node',
+      'taxonomy_term' => 'Taxonomy term',
+    );
+    $entity_manager = \Drupal::service('entity.manager');
+    foreach ($entity_types as $entity_type => $entity_label) {
+      $bundles = $entity_manager->getBundleInfo($entity_type);
+      foreach ($bundles as $bundle_id => $bundle_metadata) {
+        $metatag_defaults_id = $entity_type . '__' . $bundle_id;
+        if (empty(entity_load('metatag_defaults', $metatag_defaults_id))) {
+          $options[$entity_label][$metatag_defaults_id] = $bundle_metadata['label'];
+        }
+      }
+    }
+    return $options;
   }
 
 }

--- a/src/Form/MetatagDefaultsForm.php
+++ b/src/Form/MetatagDefaultsForm.php
@@ -24,9 +24,10 @@ class MetatagDefaultsForm extends EntityForm {
    */
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
-
     $metatag_defaults = $this->entity;
+    $metatag_manager = \Drupal::service('metatag.manager');
 
+    // Add the token browser at the top.
     $form += \Drupal::service('metatag.token')->tokenBrowser();
 
     // If this is a new Metatag defaults, then list available bundles.
@@ -39,19 +40,14 @@ class MetatagDefaultsForm extends EntityForm {
         '#options' => $options,
         '#required' => TRUE,
       );
+      $values = array();
+    }
+    else {
+      $values = $metatag_defaults->get('tags');
     }
 
-    // Load all tag plugins and render their form representation.
-    $tag_manager = \Drupal::service('plugin.manager.metatag.tag');
-    $tags = $tag_manager->getDefinitions();
-    foreach ($tags as $tag_id => $tag_definition) {
-      $tag = $tag_manager->createInstance($tag_id);
-      // If the config_entity has a value for this tag, set it.
-      if ($metatag_defaults->hasTag($tag_id)) {
-        $tag->setValue($metatag_defaults->getTag($tag_id));
-      }
-      $form[$tag_id] = $tag->form();
-    }
+    // Add metatag form fields.
+    $form = $metatag_manager->form($values, $form);
 
     return $form;
   }

--- a/src/MetatagDefaultsListBuilder.php
+++ b/src/MetatagDefaultsListBuilder.php
@@ -47,17 +47,21 @@ class MetatagDefaultsListBuilder extends ConfigEntityListBuilder {
   public function getOperations(EntityInterface $entity) {
     $operations = parent::getOperations($entity);
 
-    $operations['revert'] = array(
-      'title' => t('Revert'),
-      'weight' => $operations['edit']['weight'] + 1,
-      'url' => $entity->urlInfo('revert-form'),
-    );
+    // Global and entity defaults can be reverted but not deleted.
+    if (strpos($entity->id(), '__') === FALSE) {
+      unset($operations['delete']);
+      $operations['revert'] = array(
+        'title' => t('Revert'),
+        'weight' => $operations['edit']['weight'] + 1,
+        'url' => $entity->urlInfo('revert-form'),
+      );
+    }
 
     return $operations;
   }
 
   /**
-   * Renders the entity label plus a summary.
+   * Renders the Metatag defaults lable plus its configuration.
    *
    * @param EntityInterface $entity
    *   The Metatag defaults entity.
@@ -68,10 +72,14 @@ class MetatagDefaultsListBuilder extends ConfigEntityListBuilder {
     $output = '<div>';
     $prefix = '';
     $inherits = '';
-    // Add indentation to entities different than the global defaults.
     if ($entity->id() != 'global') {
       $prefix = '<div class="indentation"></div>';
       $inherits .= 'Global';
+    }
+    if (strpos($entity->id(), '__') !== FALSE) {
+      $prefix .= '<div class="indentation"></div>';
+      list($entity_label, $bundle_label) = explode(': ', $entity->get('label'));
+      $inherits .= ', ' . $entity_label;
     }
     $output .= '<div>
                   <p>Inherits meta tags from: ' . $inherits . '</p>

--- a/src/MetatagDefaultsListBuilder.php
+++ b/src/MetatagDefaultsListBuilder.php
@@ -100,4 +100,13 @@ class MetatagDefaultsListBuilder extends ConfigEntityListBuilder {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build['header'] = array(
+      '#markup' => '<p>' . t("To view a summary of the default meta tags and the inheritance, click on a meta tag type. If you need to set metatags for a specific entity, edit it's bundle and add the Metatag field.") . '</p>',
+    );
+    return $build + parent::render();
+  }
 }


### PR DESCRIPTION
This pull request restores bundle defaults in the admin interface and hides field defaults when editing a content type.
